### PR TITLE
lib directory is now under the project folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.1.0)
 
 project(EventLoop VERSION 2.0.0)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Threads REQUIRED)
 
@@ -20,7 +17,7 @@ set(SOURCES
     src/EventSender.cpp
     src/EventReceiver.cpp)
 
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 
 add_library(${PROJECT_NAME} SHARED
     ${INCLUDES}
@@ -30,6 +27,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
     OUTPUT_NAME ${PROJECT_NAME}
+    CXX_STANDARD_REQUIRED YES
 )
-
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Instead of the top-global CMakeLists.txt folder (CMAKE_SOURCE_DIR), the current project folder (PROJECT_SOURCE_DIR) is used.

Minor change: Instead of enforcing C++11 specifically, Compiler mode is at least C++11 (Need CMake v3.1.0).